### PR TITLE
fix: ensure zero_grad is called before backward in Autoencoder._learn

### DIFF
--- a/deep_river/anomaly/ae.py
+++ b/deep_river/anomaly/ae.py
@@ -180,9 +180,9 @@ class Autoencoder(DeepEstimator, AnomalyDetector):
         self.module.train()
         x_pred = self.module(x)
         loss = self.loss_func(x_pred, x)
+        self.optimizer.zero_grad()
         loss.backward()
         self.optimizer.step()
-        self.optimizer.zero_grad()
         return self
 
     def score_one(self, x: dict) -> float:


### PR DESCRIPTION
Thank you for the interesting project. While reviewing the code, I discovered a gradient management issue specific to the `Autoencoder._learn` method.

Initially, I thought the current gradient update sequence might be a deliberate design pattern. However, after inspecting other components, I found that all other learning processes follow the correct PyTorch order:  
`zero_grad()` → `backward()` → `step()`.

In contrast, the `Autoencoder` currently performs:  
`backward()` → `step()` → `zero_grad()`,  
which can cause gradient leakage if an exception is raised between `backward()` and `zero_grad()`.

Below is a failing test case that demonstrates this issue by simulating an exception at that point.


## Script
I have used this script for demostration. 
```python
import pytest
import torch
from deep_river.anomaly.ae import Autoencoder, _TestAutoencoder

def test_autoencoder_wrong_gradient_clearing_order():
    """This test INTENTIONALLY FAILS to demonstrate a critical bug in Autoencoder._learn method
    
    The bug: Operations are called in wrong order: loss.backward() → step() → zero_grad()
    Correct order should be: zero_grad() → loss.backward() → step()
    
    Problem: If exception occurs after backward but before zero_grad, gradients remain and accumulate
    
    Impact:
    1. Gradient accumulation leads to incorrect parameter updates
    2. Unstable training and potentially divergent behavior
    3. Effects worsen in exception handling scenarios
    """
    # Create test Autoencoder
    ae = Autoencoder(module=_TestAutoencoder, optimizer_fn="sgd")
    
    # First learning step to initialize
    ae.learn_one({'feature1': 0.5, 'feature2': 0.3})
    
    # Demonstrate the wrong operation order in _learn method:
    # current: loss.backward() → optimizer.step() → optimizer.zero_grad()
    # correct: optimizer.zero_grad() → loss.backward() → optimizer.step()
    
    # Mock backward to raise exception after computing gradients
    original_backward = torch.Tensor.backward
    
    def patched_backward(*args, **kwargs):
        original_backward(*args, **kwargs)
        # Simulate crash between backward and zero_grad
        raise RuntimeError("Simulated exception after backward() but before zero_grad()")
    
    # Apply patch
    torch.Tensor.backward = patched_backward
    
    try:
        # Exception during learning
        with pytest.raises(RuntimeError):
            ae.learn_one({'feature1': 0.2, 'feature2': 0.8})
        
        # Count gradients that still exist
        params = list(ae.module.parameters())
        params_with_grads = sum(1 for p in params if p.grad is not None)
        
        # This assertion SHOULD FAIL, showing the bug
        assert params_with_grads == 0, \
            f"BUG: {params_with_grads}/{len(params)} parameters still have gradients after exception"
            
    finally:
        # Restore original
        torch.Tensor.backward = original_backward 
```
## References
- [Zeroing out gradients in PyTorch — PyTorch Tutorials 2.7.0+cu126 documentation](https://docs.pytorch.org/tutorials/recipes/recipes/zeroing_out_gradients.html)