### PR TITLE
Updates GitHub workflows to use 'uv' instead of Poetry

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: uv-${{ runner.os }}-3.12-${{ hashFiles('**/uv.lock') }}
+          key: uv-${{ runner.os }}-3.12-${{ hashFiles('**/uv.lock', '**/poetry.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-3.12-
             uv-${{ runner.os }}-

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: uv-${{ runner.os }}-3.12-${{ hashFiles('**/uv.lock', '**/poetry.lock') }}
+          key: uv-${{ runner.os }}-3.12-${{ hashFiles('**/uv.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-3.12-
             uv-${{ runner.os }}-

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -7,36 +7,38 @@ jobs:
   ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Ubuntu dependencies
         run: sudo apt-get install graphviz pandoc
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
         with:
-          python-version: 3.12
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
+          version: "latest"
 
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
         with:
-          path: .venv
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-3.12-${{ hashFiles('**/uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-3.12-
+            uv-${{ runner.os }}-
 
-      - name: Install dependencies with river
-        run: poetry install --no-interaction
-        shell: bash
+      - name: Install dependencies
+        run: uv sync --all-extras
 
       - name: Build docs
         run: |
           cd benchmarks
-          poetry run python render.py
+          uv run python render.py
           cd ..
-          poetry run mkdocs build
+          uv run mkdocs build
 
       - name: Deploy docs
         run: |
-          poetry run mkdocs gh-deploy --force
+          uv run mkdocs gh-deploy --force

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,20 +18,29 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        run: uv python install 3.12
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
         with:
-          python-version: "3.12"
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          python-version: ${{ matrix.python }}
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-      - name: Install dependencies
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-3.12-${{ hashFiles('**/uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-3.12-
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies and build
         run: |
-          poetry build
+          uv sync
+          uv build
+
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: uv-${{ runner.os }}-3.12-${{ hashFiles('**/uv.lock', '**/poetry.lock') }}
+          key: uv-${{ runner.os }}-3.12-${{ hashFiles('**/uv.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-3.12-
             uv-${{ runner.os }}-

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: uv-${{ runner.os }}-3.12-${{ hashFiles('**/uv.lock') }}
+          key: uv-${{ runner.os }}-3.12-${{ hashFiles('**/uv.lock', '**/poetry.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-3.12-
             uv-${{ runner.os }}-

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,52 +21,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        run: uv python install ${{ matrix.python }}
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
         with:
-          python-version: ${{ matrix.python }}
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          python-version: ${{ matrix.python }}
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-
-      - name: Install Poetry (Windows fallback)
-        if: runner.os == 'Windows'
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install poetry
-        shell: powershell
-
-      - name: Configure Poetry for Windows
-        if: runner.os == 'Windows'
-        run: poetry config virtualenvs.in-project true
-        shell: powershell
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.python }}-${{ matrix.river }}-${{ hashFiles('**/poetry.lock') }}
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ matrix.python }}-${{ matrix.river }}-${{ hashFiles('**/uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ matrix.python }}-${{ matrix.river }}-
+            uv-${{ runner.os }}-${{ matrix.python }}-
+            uv-${{ runner.os }}-
 
       - name: Install dependencies with river ${{ matrix.river }}
         run: |
-          poetry add river==${{ matrix.river }}
-          poetry install --no-interaction
-        shell: bash
+          uv add river==${{ matrix.river }}
+          uv sync --all-extras
 
       - name: Download datasets
-        run: poetry run python -c "from river import datasets; datasets.CreditCard().download(); datasets.Elec2().download(); datasets.Keystroke().download()"
+        run: uv run python -c "from river import datasets; datasets.CreditCard().download(); datasets.Elec2().download(); datasets.Keystroke().download()"
 
       - name: Run tests
         run: |
           export PYTHONPATH=$PWD
-          poetry run pytest -v --cov=deep_river -m "not datasets"
-        shell: bash
+          uv run pytest -v --cov=deep_river -m "not datasets"
 
       - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ matrix.python }}-${{ matrix.river }}-${{ hashFiles('**/uv.lock', '**/poetry.lock') }}
+          key: uv-${{ runner.os }}-${{ matrix.python }}-${{ matrix.river }}-${{ hashFiles('**/uv.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-${{ matrix.python }}-${{ matrix.river }}-
             uv-${{ runner.os }}-${{ matrix.python }}-

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: uv-${{ runner.os }}-${{ matrix.python }}-${{ matrix.river }}-${{ hashFiles('**/uv.lock') }}
+          key: uv-${{ runner.os }}-${{ matrix.python }}-${{ matrix.river }}-${{ hashFiles('**/uv.lock', '**/poetry.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-${{ matrix.python }}-${{ matrix.river }}-
             uv-${{ runner.os }}-${{ matrix.python }}-

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,9 +48,9 @@ jobs:
         run: uv run python -c "from river import datasets; datasets.CreditCard().download(); datasets.Elec2().download(); datasets.Keystroke().download()"
 
       - name: Run tests
-        run: |
-          export PYTHONPATH=$PWD
-          uv run pytest -v --cov=deep_river -m "not datasets"
+        run: uv run pytest -v --cov=deep_river -m "not datasets"
+        env:
+          PYTHONPATH: ${{ github.workspace }}
 
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
Replaces Poetry with 'uv' in CI workflows to streamline Python environment setup and dependency management.

This change improves compatibility and reduces complexity by utilizing 'uv' for dependency installation, caching, and running commands.

Switches to the latest actions and ensures Python 3.12 is consistently set up across all workflows.

Enhances maintainability and future-proofs the build process.