### PR TITLE
Refactor regression tests

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -3,7 +3,6 @@ import itertools
 import json
 import logging
 import multiprocessing
-from datetime import timedelta
 from typing import List
 
 import pandas as pd

--- a/deep_river/base.py
+++ b/deep_river/base.py
@@ -642,7 +642,7 @@ class DeepEstimatorInitialized(base.Estimator):
 
     @staticmethod
     def _expand_weights(
-            param: torch.Tensor, axis: int, dims_to_add: int, n_subparams: int
+        param: torch.Tensor, axis: int, dims_to_add: int, n_subparams: int
     ):
         """
         Expands weight tensors dynamically along a given axis.
@@ -691,7 +691,7 @@ class DeepEstimatorInitialized(base.Estimator):
         else:
             n_classes = y_pred.shape[-1]
             # Access observed_classes if it exists, otherwise use an empty SortedSet
-            observed_classes = getattr(self, 'observed_classes', SortedSet())
+            observed_classes = getattr(self, "observed_classes", SortedSet())
             y = labels2onehot(y, observed_classes, n_classes, self.device)
 
         self.module.train()

--- a/deep_river/base.py
+++ b/deep_river/base.py
@@ -99,7 +99,8 @@ class DeepEstimator(base.Estimator):
 
         torch.manual_seed(seed)
 
-    def _filter_kwargs(self, fn: Callable, override=None, **kwargs) -> dict:
+    @staticmethod
+    def _filter_kwargs(fn: Callable, override=None, **kwargs) -> dict:
         """Filters `net_params` and returns those in `fn`'s arguments.
 
         Parameters
@@ -135,9 +136,9 @@ class DeepEstimator(base.Estimator):
         """
         Parameters
         ----------
-        module
-          The instance or class or callable to be initialized, e.g.
-          ``self.module``.
+        x
+            The first input example or batch of examples. Can be a dictionary
+            or a pandas DataFrame.
         kwargs : dict
           The keyword arguments to initialize the instance or class. Can be an
           empty dict.
@@ -147,6 +148,7 @@ class DeepEstimator(base.Estimator):
           The initialized component.
         """
         torch.manual_seed(self.seed)
+        n_features = 0
         if isinstance(x, Dict):
             n_features = len(x)
         elif isinstance(x, pd.DataFrame):
@@ -638,8 +640,9 @@ class DeepEstimatorInitialized(base.Estimator):
 
                     setattr(layer, param_name, param)
 
+    @staticmethod
     def _expand_weights(
-        self, param: torch.Tensor, axis: int, dims_to_add: int, n_subparams: int
+            param: torch.Tensor, axis: int, dims_to_add: int, n_subparams: int
     ):
         """
         Expands weight tensors dynamically along a given axis.

--- a/deep_river/regression/__init__.py
+++ b/deep_river/regression/__init__.py
@@ -7,6 +7,7 @@ from deep_river.regression.rolling_regressor import (
     RollingRegressor,
     RollingRegressorInitialized,
 )
+from deep_river.regression.zoo import LinearRegressionInitialized,LSTMRegressorInitialized,MultiLayerPerceptronInitialized
 
 """
 This module contains the regressors for the deep_river package.
@@ -18,4 +19,7 @@ __all__ = [
     "RollingRegressorInitialized",
     "MultiTargetRegressor",
     "MultiTargetRegressorInitialized",
+    "LinearRegressionInitialized",
+    "LSTMRegressorInitialized",
+    "MultiLayerPerceptronInitialized"
 ]

--- a/deep_river/regression/__init__.py
+++ b/deep_river/regression/__init__.py
@@ -7,7 +7,11 @@ from deep_river.regression.rolling_regressor import (
     RollingRegressor,
     RollingRegressorInitialized,
 )
-from deep_river.regression.zoo import LinearRegressionInitialized,LSTMRegressorInitialized,MultiLayerPerceptronInitialized
+from deep_river.regression.zoo import (
+    LinearRegressionInitialized,
+    LSTMRegressorInitialized,
+    MultiLayerPerceptronInitialized,
+)
 
 """
 This module contains the regressors for the deep_river package.
@@ -21,5 +25,5 @@ __all__ = [
     "MultiTargetRegressorInitialized",
     "LinearRegressionInitialized",
     "LSTMRegressorInitialized",
-    "MultiLayerPerceptronInitialized"
+    "MultiLayerPerceptronInitialized",
 ]

--- a/deep_river/regression/zoo.py
+++ b/deep_river/regression/zoo.py
@@ -190,6 +190,7 @@ class LSTMRegressorInitialized(RollingRegressorInitialized):
     **kwargs
         Additional parameters to be passed to the parent class.
     """
+
     class LSTMModule(nn.Module):
         def __init__(self, n_features, output_size=1):
             super().__init__()

--- a/deep_river/regression/zoo.py
+++ b/deep_river/regression/zoo.py
@@ -18,12 +18,6 @@ class LinearRegressionInitialized(RegressorInitialized):
         Optimizer to be used for training the wrapped model.
     lr : float
         Learning rate of the optimizer.
-    output_is_logit : bool
-        Whether the module produces logits as output. If true, either
-        softmax or sigmoid is applied to the outputs when predicting.
-    is_class_incremental : bool
-        Whether the classifier should adapt to the appearance of previously unobserved classes
-        by adding an unit to the output layer of the network.
     is_feature_incremental : bool
         Whether the model should adapt to the appearance of previously features by
         adding units to the input layer of the network.
@@ -46,10 +40,9 @@ class LinearRegressionInitialized(RegressorInitialized):
     def __init__(
         self,
         n_features: int = 10,
-        loss_fn: Union[str, Callable] = "binary_cross_entropy_with_logits",
+        loss_fn: Union[str, Callable] = "mse",
         optimizer_fn: Union[str, Type[optim.Optimizer]] = "sgd",
         lr: float = 1e-3,
-        output_is_logit: bool = True,
         is_feature_incremental: bool = False,
         device: str = "cpu",
         seed: int = 42,
@@ -63,7 +56,6 @@ class LinearRegressionInitialized(RegressorInitialized):
             module=module,
             loss_fn=loss_fn,
             optimizer_fn=optimizer_fn,
-            output_is_logit=output_is_logit,
             is_feature_incremental=is_feature_incremental,
             device=device,
             lr=lr,
@@ -97,9 +89,6 @@ class MultiLayerPerceptronInitialized(RegressorInitialized):
         Optimizer to be used for training the wrapped model.
     lr : float
         Learning rate of the optimizer.
-    output_is_logit : bool
-        Whether the module produces logits as output. If true, either
-        softmax or sigmoid is applied to the outputs when predicting.
     is_class_incremental : bool
         Whether the classifier should adapt to the appearance of previously unobserved classes
         by adding an unit to the output layer of the network.
@@ -133,10 +122,9 @@ class MultiLayerPerceptronInitialized(RegressorInitialized):
         n_features: int = 10,
         n_width: int = 5,
         n_layers: int = 5,
-        loss_fn: Union[str, Callable] = "binary_cross_entropy_with_logits",
+        loss_fn: Union[str, Callable] = "mse",
         optimizer_fn: Union[str, Type[optim.Optimizer]] = "sgd",
         lr: float = 1e-3,
-        output_is_logit: bool = True,
         is_feature_incremental: bool = False,
         device: str = "cpu",
         seed: int = 42,
@@ -154,7 +142,6 @@ class MultiLayerPerceptronInitialized(RegressorInitialized):
             module=module,
             loss_fn=loss_fn,
             optimizer_fn=optimizer_fn,
-            output_is_logit=output_is_logit,
             is_feature_incremental=is_feature_incremental,
             device=device,
             lr=lr,
@@ -177,7 +164,32 @@ class MultiLayerPerceptronInitialized(RegressorInitialized):
 
 
 class LSTMRegressorInitialized(RollingRegressorInitialized):
+    """
+    LSTM Regressor model for time series regression.
 
+    This model uses LSTM (Long Short-Term Memory) networks to capture temporal
+    dependencies in sequential data for regression tasks.
+
+    Parameters
+    ----------
+    n_features : int
+        Number of input features.
+    loss_fn : str or Callable
+        Loss function to be used for training the wrapped model.
+    optimizer_fn : str or Callable
+        Optimizer to be used for training the wrapped model.
+    lr : float
+        Learning rate of the optimizer.
+    is_feature_incremental : bool
+        Whether the model should adapt to the appearance of previously features by
+        adding units to the input layer of the network.
+    device : str
+        Device to run the wrapped model on. Can be "cpu" or "cuda".
+    seed : int
+        Random seed to be used for training the wrapped model.
+    **kwargs
+        Additional parameters to be passed to the parent class.
+    """
     class LSTMModule(nn.Module):
         def __init__(self, n_features, output_size=1):
             super().__init__()
@@ -196,10 +208,9 @@ class LSTMRegressorInitialized(RollingRegressorInitialized):
     def __init__(
         self,
         n_features: int = 10,
-        loss_fn: Union[str, Callable] = "binary_cross_entropy_with_logits",
+        loss_fn: Union[str, Callable] = "mse",
         optimizer_fn: Union[str, Type[optim.Optimizer]] = "sgd",
         lr: float = 1e-3,
-        output_is_logit: bool = True,
         is_feature_incremental: bool = False,
         device: str = "cpu",
         seed: int = 42,


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the regression models and base utilities in the `deep_river` package. The main changes include the addition of new initialized regression models to the public API, simplification of model initialization parameters, and improved documentation for the LSTM regressor. There are also minor code style and static method refactors for better maintainability.

### Regression model API enhancements

* Added `LinearRegressionInitialized`, `LSTMRegressorInitialized`, and `MultiLayerPerceptronInitialized` to the public API in `deep_river/regression/__init__.py`, making these initialized models available for import and use. [[1]](diffhunk://#diff-1ba12b1bb655b0f1f4d4ab7ee814119dce2b3a3b79220a12308718e02a5ae023R10-R14) [[2]](diffhunk://#diff-1ba12b1bb655b0f1f4d4ab7ee814119dce2b3a3b79220a12308718e02a5ae023R26-R28)

### Regression model parameter refactoring

* Removed the unused `output_is_logit` parameter from `LinearRegressionInitialized` and `MultiLayerPerceptronInitialized`, and updated their default loss function to `"mse"` for consistency with regression tasks. [[1]](diffhunk://#diff-bdd980bc00ad78ed15f1e35d4619144a5d61c2dd348598fff1b150cdf90ee2f1L21-L26) [[2]](diffhunk://#diff-bdd980bc00ad78ed15f1e35d4619144a5d61c2dd348598fff1b150cdf90ee2f1L49-L52) [[3]](diffhunk://#diff-bdd980bc00ad78ed15f1e35d4619144a5d61c2dd348598fff1b150cdf90ee2f1L66) [[4]](diffhunk://#diff-bdd980bc00ad78ed15f1e35d4619144a5d61c2dd348598fff1b150cdf90ee2f1L100-L102) [[5]](diffhunk://#diff-bdd980bc00ad78ed15f1e35d4619144a5d61c2dd348598fff1b150cdf90ee2f1L136-L139) [[6]](diffhunk://#diff-bdd980bc00ad78ed15f1e35d4619144a5d61c2dd348598fff1b150cdf90ee2f1L157)
* Updated `LSTMRegressorInitialized` to use `"mse"` as the default loss function and removed the `output_is_logit` parameter.

### Documentation improvements

* Added a comprehensive docstring to `LSTMRegressorInitialized`, detailing its parameters and purpose for time series regression.

### Base utilities and code style

* Made `_filter_kwargs` and `_expand_weights` static methods in `deep_river/base.py` for clarity and proper usage. [[1]](diffhunk://#diff-74cad12e079db6f690d487b46ce805b55ea647aa5f399487e1fd197dcf076b75L102-R103) [[2]](diffhunk://#diff-74cad12e079db6f690d487b46ce805b55ea647aa5f399487e1fd197dcf076b75R643-R645)
* Minor code style fixes and clarification of parameter documentation in `initialize_module`. [[1]](diffhunk://#diff-74cad12e079db6f690d487b46ce805b55ea647aa5f399487e1fd197dcf076b75L138-R141) [[2]](diffhunk://#diff-74cad12e079db6f690d487b46ce805b55ea647aa5f399487e1fd197dcf076b75R151) [[3]](diffhunk://#diff-74cad12e079db6f690d487b46ce805b55ea647aa5f399487e1fd197dcf076b75L691-R694) [[4]](diffhunk://#diff-98b7d852919e49e8e4784c09c780dc4325906fd6ab2407a5c021cdc0a0052d93L6)